### PR TITLE
Update logging with the default logger

### DIFF
--- a/docs/template/logging.mdx
+++ b/docs/template/logging.mdx
@@ -85,7 +85,6 @@ The `onBuildLogs`/`on_build_logs` callback receives structured `LogEntry` object
 <CodeGroup>
 
 ```typescript JavaScript & TypeScript
-// Log levels
 type LogEntryLevel = 'debug' | 'info' | 'warn' | 'error'
 
 class LogEntry {
@@ -114,7 +113,6 @@ class LogEntryEnd extends LogEntry {
 ```
 
 ```python Python
-# Log levels
 LogEntryLevel = Literal["debug", "info", "warn", "error"]
 
 @dataclass


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates logging docs to introduce the default logger and document LogEntry hierarchy (including Start/End) with TS/Python examples.
> 
> - **Docs (logging)**:
>   - **Default Logger**: Add `defaultBuildLogger`/`default_build_logger` usage with configurable `minLevel`/`min_level` in TS/Python examples.
>   - **Custom Logger**: Keep and clarify examples for simple, formatted, and level-filtered logging.
>   - **Types**: Expand `LogEntry` docs and add `LogEntryStart` and `LogEntryEnd` types (default `debug`), with examples of detecting them in TS/Python.
>   - **Structure**: Reorganize section from generic SDK description to distinct Default Logger and Custom Logger sections, moving/expanding type definitions accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acae5a2647d25b835b366c58176dbd3916960ec2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->