### PR TITLE
feat: move template user and workdir to a separate page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -95,6 +95,7 @@
             "pages": [
               "docs/template/quickstart",
               "docs/template/how-it-works",
+              "docs/template/user-and-workdir",
               "docs/template/caching",
               "docs/template/base-image",
               "docs/template/private-registries",
@@ -153,18 +154,24 @@
           },
           {
             "group": "Deployment",
-            "pages": ["docs/byoc"]
+            "pages": [
+              "docs/byoc"
+            ]
           },
           {
             "group": "Migration",
-            "pages": ["docs/migration/v2"]
+            "pages": [
+              "docs/migration/v2"
+            ]
           },
           {
             "group": "Troubleshooting",
             "pages": [
               {
                 "group": "SDKs",
-                "pages": ["docs/troubleshooting/sdks/workers-edge-runtime"]
+                "pages": [
+                  "docs/troubleshooting/sdks/workers-edge-runtime"
+                ]
               },
               {
                 "group": "Templates",

--- a/docs/template/how-it-works.mdx
+++ b/docs/template/how-it-works.mdx
@@ -24,75 +24,7 @@ We call this sandbox snapshot a _sandbox template_.
 </Note>
 
 ## Default User And Workdir
-The default user in the template is `user` with the `/home/user` (home directory) as the working directory.
-This is different from the Docker defaults, where the default user is `root` with `/` as the working directory. This is to help with tools installation, and to improve default security.
-
-The last set user and workdir in the template is then persisted as a default to the sandbox execution.
-Example of setting user and workdir in the template definition are below.
-
-<Info>
-    Requires the E2B SDK version at least 2.3.0
-</Info>
-
-<CodeGroup>
-```typescript JavaScript & TypeScript
-const template = Template()
-  .fromBaseImage()
-  .runCmd("whoami") // user
-  .runCmd("pwd") // /home/user
-  .setUser("guest")
-  .runCmd("whoami") // guest
-  .runCmd("pwd") // /home/guest
-
-const sbx = await Sandbox.create()
-await sbx.commands.run("whoami") // guest
-await sbx.commands.run("pwd") // /home/guest
-```
-
-```python Python
-template = (
-    Template()
-    .from_base_image()
-    .run_cmd("whoami") # user
-    .run_cmd("pwd") # /home/user
-    .set_user("guest")
-    .run_cmd("whoami") # guest
-    .run_cmd("pwd") # /home/guest
-)
-
-sbx = Sandbox.create()
-sbx.commands.run("whoami")  # guest
-sbx.commands.run("pwd")  # /home/guest
-```
-
-</CodeGroup>
-
-<CodeGroup>
-```typescript JavaScript & TypeScript
-const template = Template()
-  .fromBaseImage()
-  .runCmd("whoami") // user
-  .runCmd("pwd") // /home/user
-
-const sbx = await Sandbox.create()
-await sbx.commands.run("whoami") // user
-await sbx.commands.run("pwd") // /home/user
-```
-
-```python Python
-template = (
-    Template()
-    .from_base_image()
-    .run_cmd("whoami")  # user
-    .run_cmd("pwd")  # /home/user
-)
-
-sbx = Sandbox.create()
-sbx.commands.run("whoami")  # user
-sbx.commands.run("pwd")  # /home/user
-```
-
-</CodeGroup>
+To learn more about default user and workdir, please refer to the [User And Workdir](/docs/template/user-and-workdir) section.
 
 
 ## Caching

--- a/docs/template/user-and-workdir.mdx
+++ b/docs/template/user-and-workdir.mdx
@@ -1,0 +1,74 @@
+---
+title: "User And Workdir"
+description: "Default user and working directory in the sandbox and template"
+---
+
+The default user in the template is `user` with the `/home/user` (home directory) as the working directory.
+This is different from the Docker defaults, where the default user is `root` with `/` as the working directory. This is to help with tools installation, and to improve default security.
+
+The last set user and workdir in the template is then persisted as a default to the sandbox execution.
+Example of setting user and workdir in the template definition are below.
+
+<Info>
+    Requires the E2B SDK version at least 2.3.0
+</Info>
+
+<CodeGroup>
+```typescript JavaScript & TypeScript
+const template = Template()
+  .fromBaseImage()
+  .runCmd("whoami") // user
+  .runCmd("pwd") // /home/user
+  .setUser("guest")
+  .runCmd("whoami") // guest
+  .runCmd("pwd") // /home/guest
+
+const sbx = await Sandbox.create()
+await sbx.commands.run("whoami") // guest
+await sbx.commands.run("pwd") // /home/guest
+```
+
+```python Python
+template = (
+    Template()
+    .from_base_image()
+    .run_cmd("whoami") # user
+    .run_cmd("pwd") # /home/user
+    .set_user("guest")
+    .run_cmd("whoami") # guest
+    .run_cmd("pwd") # /home/guest
+)
+
+sbx = Sandbox.create()
+sbx.commands.run("whoami")  # guest
+sbx.commands.run("pwd")  # /home/guest
+```
+
+</CodeGroup>
+
+<CodeGroup>
+```typescript JavaScript & TypeScript
+const template = Template()
+  .fromBaseImage()
+  .runCmd("whoami") // user
+  .runCmd("pwd") // /home/user
+
+const sbx = await Sandbox.create()
+await sbx.commands.run("whoami") // user
+await sbx.commands.run("pwd") // /home/user
+```
+
+```python Python
+template = (
+    Template()
+    .from_base_image()
+    .run_cmd("whoami")  # user
+    .run_cmd("pwd")  # /home/user
+)
+
+sbx = Sandbox.create()
+sbx.commands.run("whoami")  # user
+sbx.commands.run("pwd")  # /home/user
+```
+
+</CodeGroup>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves the template user/workdir docs to a new page and updates how-it-works to link to it, adding the page to navigation.
> 
> - **Docs – Templates**:
>   - **New page**: `docs/template/user-and-workdir` with user/workdir defaults and code examples.
>   - **Refactor**: `docs/template/how-it-works.mdx` replaces the inlined user/workdir section with a link to the new page.
> - **Navigation**:
>   - Add `docs/template/user-and-workdir` to `docs.json` under Templates; minor array formatting tweaks in Deployment/Migration/Troubleshooting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1af8dabdb4f2dc75412df12996c6ab00e985ef05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->