### PR TITLE
Events and webhooks V2

### DIFF
--- a/docs/sandbox/lifecycle-events-api.mdx
+++ b/docs/sandbox/lifecycle-events-api.mdx
@@ -46,6 +46,7 @@ console.log(teamSandboxEvents)
 // [
 //   {
 //     "version": "v1",
+//     "id": "f5911677-cb60-498f-afed-f68143b3cc59",
 //     "type": "sandbox.lifecycle.killed",
 //     "eventData": null,
 //     "sandboxBuildId": "a979a14b-bdcc-49e6-bc04-1189fc9fe7c2",
@@ -57,6 +58,7 @@ console.log(teamSandboxEvents)
 //   },
 //   {
 //     "version": "v1",
+//     "id": "30b09e11-9ba2-42db-9cf6-d21f0f43a234",
 //     "type": "sandbox.lifecycle.updated",
 //     "eventData": {
 //       "set_timeout": "2025-08-06T20:59:59Z"
@@ -71,6 +73,7 @@ console.log(teamSandboxEvents)
 //   [...]
 //   {
 //     "version": "v1",
+//     "id": "0568572b-a2ac-4e5f-85fa-fae90905f556",
 //     "type": "sandbox.lifecycle.created",
 //     "eventData": null,
 //     "sandboxBuildId": "a979a14b-bdcc-49e6-bc04-1189fc9fe7c2",
@@ -111,6 +114,7 @@ print(team_sandbox_events)
 # [
 #   {
 #     "version": "v1",
+#     "id": "0568572b-a2ac-4e5f-85fa-fae90905f556",
 #     "type": "sandbox.lifecycle.killed",
 #     "eventData": null,
 #     "sandboxBuildId": "a979a14b-bdcc-49e6-bc04-1189fc9fe7c2",
@@ -122,6 +126,7 @@ print(team_sandbox_events)
 #   },
 #   {
 #     "version": "v1",
+#     "id": "e7013704-2c51-4dd2-9f6c-388c91460149",
 #     "type": "sandbox.lifecycle.updated",
 #     "eventData": {
 #       "set_timeout": "2025-08-06T20:59:59Z"
@@ -136,6 +141,7 @@ print(team_sandbox_events)
 #   [...]
 #   {
 #     "version": "v1",
+#     "id": "f29ef778-2743-4c97-a802-7ba67f84ce24",
 #     "type": "sandbox.lifecycle.created",
 #     "eventData": null,
 #     "sandboxBuildId": "a979a14b-bdcc-49e6-bc04-1189fc9fe7c2",

--- a/docs/sandbox/lifecycle-events-webhooks.mdx
+++ b/docs/sandbox/lifecycle-events-webhooks.mdx
@@ -252,6 +252,7 @@ The payload structure matches the event format from the API:
 ```json
 {
   "version": "v1",
+  "id": "<event-id>",
   "type": "<sandbox-event-type>",
   "eventData": {
     "sandbox_metadata": {
@@ -271,7 +272,6 @@ The payload structure matches the event format from the API:
 When webhooks is send, we are adding headers to help you verify the authenticity of the request and make debugging easier.
 
 - `e2b-webhook-id` - Webhook ID that triggered the event
-- `e2b-event-id` - Unique ID for the event
 - `e2b-delivery-id` - Unique ID for the delivery attempt
 - `e2b-signature-version` - Currently always `v1`, reserved for future use
 - `e2b-signature` - SHA256 signature of `${signatureSecret}${requestBodyString}`


### PR DESCRIPTION
- Added new event format (there is full back compatibility).
- Added new API for webhooks management that breaks compatibility as it supports more webhooks per team.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refresh docs to the v1 event schema and add full v2 webhooks management docs with new endpoints, payloads, and headers.
> 
> - **Docs — Lifecycle events API (`docs/sandbox/lifecycle-events-api.mdx`)**:
>   - Update event payload/examples to new format: add `version`, `id`, `type`; remove `eventCategory`/`eventLabel`.
> - **Docs — Webhooks (`docs/sandbox/lifecycle-events-webhooks.mdx`)**:
>   - Introduce new webhooks management endpoints at `events/webhooks` with CRUD + list; examples for JS/Python.
>   - Registration/update payload now supports `name`, `enabled`, namespaced `events` (e.g., `sandbox.lifecycle.created`), and `signatureSecret`.
>   - Add webhook request headers (`e2b-webhook-id`, `e2b-delivery-id`, `e2b-signature*`) section.
>   - Update webhook payload example to new event schema and namespaced event types; remove legacy "Test webhook" section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90f7d373d10b71a673acfd3d9ef2949b7aef17b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->