### PR TITLE
Add Browserbase MCP to the MCP quickstart example

### DIFF
--- a/docs/mcp/quickstart.mdx
+++ b/docs/mcp/quickstart.mdx
@@ -16,6 +16,11 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 
 const sandbox = await Sandbox.betaCreate({
     mcp: {
+        browserbase: {
+            apiKey: process.env.BROWSERBASE_API_KEY!,
+            geminiApiKey: process.env.GEMINI_API_KEY!,
+            projectId: process.env.BROWSERBASE_PROJECT_ID!,
+        },
         exa: {
             apiKey: process.env.EXA_API_KEY!,
         },
@@ -62,7 +67,12 @@ from mcp.client.streamable_http import streamablehttp_client
 
 async def main():
     sandbox = await AsyncSandbox.beta_create(
-        mcp={
+        mcp={            
+            "browserbase": {
+                "apiKey": os.environ["BROWSERBASE_API_KEY"],
+                "geminiApiKey": os.environ["GEMINI_API_KEY"],
+                "projectId": os.environ["BROWSERBASE_PROJECT_ID"],
+            },
             "exa": {
                 "apiKey": os.environ["EXA_API_KEY"],
             },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Browserbase MCP config to JS/Python quickstart samples and fixes a list bullet formatting issue.
> 
> - **Docs (MCP Quickstart)**
>   - **Examples**:
>     - TypeScript: add `mcp.browserbase` with `apiKey`, `geminiApiKey`, and `projectId` in `Sandbox.betaCreate`.
>     - Python: add `"browserbase"` with `apiKey`, `geminiApiKey`, and `projectId` in `AsyncSandbox.beta_create`.
>   - **Formatting**: fix bullet for "Debug connection issues" in the MCP Inspector section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b7cfe5c9d00398a844aa0b3296885a3478ff298. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->