### PR TITLE
Remove beta for MCP

### DIFF
--- a/docs/mcp.mdx
+++ b/docs/mcp.mdx
@@ -16,7 +16,7 @@ The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-
 ```typescript TypeScript
 import Sandbox from 'e2b'
 
-const sbx = await Sandbox.betaCreate({
+const sbx = await Sandbox.create({
     mcp: {
         browserbase: {
             apiKey: process.env.BROWSERBASE_API_KEY!,
@@ -32,8 +32,8 @@ const sbx = await Sandbox.betaCreate({
     },
 });
 
-const mcpUrl = sbx.betaGetMcpUrl();
-const mcpToken = await sbx.betaGetMcpToken();
+const mcpUrl = sbx.getMcpUrl();
+const mcpToken = await sbx.getMcpToken();
 
 // You can now connect the gateway to any MCP client, for example claude:
 // This also works for your local claude!
@@ -55,7 +55,7 @@ import dotenv
 dotenv.load_dotenv()
 
 async def main():
-    sbx = await AsyncSandbox.beta_create(mcp={
+    sbx = await AsyncSandbox.create(mcp={
         "browserbase": {
             "apiKey": os.getenv("BROWSERBASE_API_KEY"),
             "geminiApiKey": os.getenv("GEMINI_API_KEY"),
@@ -69,8 +69,8 @@ async def main():
         },
     })
 
-    mcp_url = sbx.beta_get_mcp_url()
-    mcp_token = await sbx.beta_get_mcp_token()
+    mcp_url = sbx.get_mcp_url()
+    mcp_token = await sbx.get_mcp_token()
 
     # You can now connect the gateway to any MCP client, for example claude:
     # This also works for your local claude!

--- a/docs/mcp/custom-servers.mdx
+++ b/docs/mcp/custom-servers.mdx
@@ -21,7 +21,7 @@ The `runCmd` must start an MCP server that follows the [MCP specification](https
 ```typescript TypeScript
 import Sandbox from 'e2b'
 
-const sandbox = await Sandbox.betaCreate({
+const sandbox = await Sandbox.create({
     mcp: {
         'github/modelcontextprotocol/servers': {
             installCmd: 'npm install',
@@ -35,7 +35,7 @@ const sandbox = await Sandbox.betaCreate({
 from e2b import Sandbox
 import os
 
-sbx = Sandbox.beta_create(
+sbx = Sandbox.create(
     mcp={
         "github/modelcontextprotocol/servers": {
                 "install_cmd": "npm install",

--- a/docs/mcp/custom-templates.mdx
+++ b/docs/mcp/custom-templates.mdx
@@ -14,7 +14,7 @@ You must use the MCP gateway enabled template (`mcp-gateway`) as your base templ
 
 ## Building a template with MCP servers
 
-Use the `betaAddMcpServer()` method (TypeScript) or `beta_add_mcp_server()` method (Python) to prepull MCP server images during template build. You can pass a single server or an array of servers.
+Use the `addMcpServer()` method (TypeScript) or `add_mcp_server()` method (Python) to prepull MCP server images during template build. You can pass a single server or an array of servers.
 
 The server names (like `"browserbase"` and `"exa"`) correspond to the keys defined in the [Available Servers](/docs/mcp/available-servers) documentation.
 
@@ -26,7 +26,7 @@ import { Template } from "e2b";
 
 export const template = Template()
   .fromTemplate("mcp-gateway")
-  .betaAddMcpServer(["browserbase", "exa"]);
+  .addMcpServer(["browserbase", "exa"]);
 
 await Template.build(template, {
   alias: "my-mcp-gateway",
@@ -45,7 +45,7 @@ load_dotenv()
 template = (
     Template()
     .from_template("mcp-gateway")
-    .beta_add_mcp_server(["browserbase", "exa"])
+    .add_mcp_server(["browserbase", "exa"])
 )
 
 Template.build(
@@ -67,7 +67,7 @@ Once built, create sandboxes from your template alias. You still need to provide
 ```typescript JavaScript & TypeScript
 import { Sandbox } from "e2b";
 
-const sandbox = await Sandbox.betaCreate({
+const sandbox = await Sandbox.create({
     template: "my-mcp-gateway",
     mcp: {
         browserbase: {
@@ -87,7 +87,7 @@ const sandbox = await Sandbox.betaCreate({
 from e2b import Sandbox
 import os
 
-sbx = Sandbox.beta_create(
+sbx = Sandbox.create(
     template="my-mcp-gateway",
     mcp={
         "browserbase": {

--- a/docs/mcp/quickstart.mdx
+++ b/docs/mcp/quickstart.mdx
@@ -7,14 +7,14 @@ You can connect to the MCPs running inside the sandbox both from outside and ins
 
 ## From outside the sandbox
 
-To connect to the MCPs running inside the sandbox, use the `sandbox.betaGetMcpUrl()` in JavaScript and `sandbox.beta_get_mcp_url()` in Python.
+To connect to the MCPs running inside the sandbox, use the `sandbox.getMcpUrl()` in JavaScript and `sandbox.get_mcp_url()` in Python.
 <CodeGroup>
 ```typescript TypeScript
 import Sandbox from 'e2b'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
-const sandbox = await Sandbox.betaCreate({
+const sandbox = await Sandbox.create({
     mcp: {
         browserbase: {
             apiKey: process.env.BROWSERBASE_API_KEY!,
@@ -36,11 +36,11 @@ const client = new Client({
 });
 
 const transport = new StreamableHTTPClientTransport(
-    new URL(sandbox.betaGetMcpUrl()), 
+    new URL(sandbox.getMcpUrl()), 
     {
         requestInit: {
             headers: {
-                'Authorization': `Bearer ${await sandbox.betaGetMcpToken()}`
+                'Authorization': `Bearer ${await sandbox.getMcpToken()}`
             }
         }
     }
@@ -66,7 +66,7 @@ from mcp.client.session import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
 async def main():
-    sandbox = await AsyncSandbox.beta_create(
+    sandbox = await AsyncSandbox.create(
         mcp={            
             "browserbase": {
                 "apiKey": os.environ["BROWSERBASE_API_KEY"],
@@ -83,8 +83,8 @@ async def main():
     )
 
     async with streamablehttp_client(
-        url=sandbox.beta_get_mcp_url(),
-        headers={"Authorization": f"Bearer {await sandbox.beta_get_mcp_token()}"},
+        url=sandbox.get_mcp_url(),
+        headers={"Authorization": f"Bearer {await sandbox.get_mcp_token()}"},
         timeout=timedelta(seconds=600)
     ) as (read_stream, write_stream, _):
         async with ClientSession(read_stream, write_stream) as session:
@@ -124,7 +124,7 @@ const mcp = new MCPServerStreamableHttp({
     name: 'E2B MCP Gateway',
     requestInit: {
         headers: {
-            'Authorization': `Bearer ${await sandbox.betaGetMcpToken()}`
+            'Authorization': `Bearer ${await sandbox.getMcpToken()}`
         }
     },
 });
@@ -140,8 +140,8 @@ async def main():
     async with MCPServerStreamableHttp(
         name="e2b-mcp-client",
         params={
-            "url": sandbox.beta_get_mcp_url(),
-            "headers": {"Authorization": f"Bearer {await sandbox.beta_get_mcp_token()}"},
+            "url": sandbox.get_mcp_url(),
+            "headers": {"Authorization": f"Bearer {await sandbox.get_mcp_token()}"},
         },
     ) as server:
         tools = await server.list_tools()
@@ -167,11 +167,11 @@ const client = new Client({
 });
 
 const transport = new StreamableHTTPClientTransport(
-    new URL(sandbox.betaGetMcpUrl()), 
+    new URL(sandbox.getMcpUrl()), 
     {
         requestInit: {
             headers: {
-                'Authorization': `Bearer ${await sandbox.betaGetMcpToken()}`
+                'Authorization': `Bearer ${await sandbox.getMcpToken()}`
             }
         }
     }
@@ -186,8 +186,8 @@ from mcp.client.streamable_http import streamablehttp_client
 
 async def main():
     async with streamablehttp_client(
-        url=sandbox.beta_get_mcp_url(),
-        headers={"Authorization": f"Bearer {await sandbox.beta_get_mcp_token()}"},
+        url=sandbox.get_mcp_url(),
+        headers={"Authorization": f"Bearer {await sandbox.get_mcp_token()}"},
         timeout=timedelta(seconds=600)
     ) as (read_stream, write_stream, _):
         async with ClientSession(read_stream, write_stream) as session:


### PR DESCRIPTION
Only approve once new SDK is released please

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates MCP docs to use stable Sandbox/AsyncSandbox create and MCP URL/token methods, and stable template APIs in TS/Python examples.
> 
> - **Docs**
>   - **General**: Replace `beta` MCP APIs with stable versions in TypeScript and Python examples.
>   - **Overview (`docs/mcp.mdx`)**:
>     - `Sandbox.betaCreate` → `Sandbox.create`
>     - `sbx.betaGetMcpUrl()/betaGetMcpToken()` → `sbx.getMcpUrl()/getMcpToken()`
>     - Python: `AsyncSandbox.beta_create` → `AsyncSandbox.create`; `beta_get_mcp_url/token` → `get_mcp_url/token`.
>   - **Custom Servers (`docs/mcp/custom-servers.mdx`)**:
>     - `Sandbox.betaCreate` → `Sandbox.create`
>     - Python: `Sandbox.beta_create` → `Sandbox.create`.
>   - **Custom Templates (`docs/mcp/custom-templates.mdx`)**:
>     - Template: `betaAddMcpServer` → `addMcpServer`; Python `beta_add_mcp_server` → `add_mcp_server`.
>     - Sandbox usage: `Sandbox.betaCreate` → `Sandbox.create`; Python `Sandbox.beta_create` → `Sandbox.create`.
>   - **Quickstart (`docs/mcp/quickstart.mdx`)**:
>     - Update guidance and code to `sandbox.getMcpUrl()/getMcpToken()` and `Sandbox.create`/`AsyncSandbox.create`.
>     - Update OpenAI Agents and Official MCP Client snippets to use `getMcpUrl()/getMcpToken()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9011900dcfc4c31b4acda51450cf17a7907818c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->