### PR TITLE
Enhance MCP overview with mentions of tools

### DIFF
--- a/docs/mcp.mdx
+++ b/docs/mcp.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: Connect to 200+ tools through the Model Context Protocol
 ---
 
-E2B provides a batteries-included MCP gateway that runs inside sandboxes, giving you type-safe access to 200+ MCP tools from the [Docker MCP Catalog](https://hub.docker.com/mcp) or [custom MCPs](/docs/mcp/custom-servers) through a unified interface.
+E2B provides a batteries-included MCP gateway that runs inside sandboxes, giving you type-safe access to 200+ MCP tools from the [Docker MCP Catalog](https://hub.docker.com/mcp) or [custom MCPs](/docs/mcp/custom-servers) through a unified interface. This integration gives developers instant access to tools like [Browserbase](https://www.browserbase.com/), [Exa](https://exa.ai/), [Notion](https://www.notion.so/), [Stripe](https://stripe.com/), or [GitHub](https://github.com/).
 
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) is an open standard for connecting AI models to external tools and data sources. E2B sandboxes provide an ideal environment for running MCP tools, giving AI full access to an internet-connected Linux machine where it can safely install packages, write files, run terminal commands, and AI-generated code.
 


### PR DESCRIPTION
Expanded the overview to include examples of tools integrated with the MCP gateway.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands the MCP overview intro to list example tools (Browserbase, Exa, Notion, Stripe, GitHub).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdd53deb7c5f57336651c244e1720370998fc2b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->