### PR TITLE
Add cookbook examples

### DIFF
--- a/docs/mcp/examples.mdx
+++ b/docs/mcp/examples.mdx
@@ -3,28 +3,26 @@ title: Examples
 description: Example projects using MCP servers in E2B sandboxes
 ---
 
-<CardGroup cols={2}>
-  <Card title="MCP Client" icon="plug" href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/mcp-client-js">
-    Basic MCP client connecting to an E2B sandbox
-  </Card>
-  <Card title="Custom Server" icon="server" href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/mcp-custom-server-js">
-    Connect to a custom filesystem MCP server from GitHub
-  </Card>
-  <Card title="Custom Template" icon="box" href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/mcp-custom-template-js">
-    Create a custom E2B template with pre-installed MCP servers
-  </Card>
-  <Card title="Research Agent" icon="magnifying-glass" href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/mcp-research-agent-js">
-    Research agent using the OpenAI Agents framework and MCP servers
-  </Card>
+<CardGroup cols={3}>
   <Card title="Claude Code" icon="terminal" href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/mcp-claude-code-js">
     Claude Code with MCP integration
   </Card>
   <Card title="Browserbase" icon="browser" href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/mcp-browserbase-js">
-    Web automation agent using the Browserbase MCP server
+    Web automation agent with Browserbase
   </Card>
   <Card title="Groq + Exa" icon="sparkles" href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/mcp-groq-exa-js">
-    AI research using Groq with the Exa MCP server
+    AI research using Groq and Exa
+  </Card>
+  <Card title="Research Agent" icon="magnifying-glass" href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/mcp-research-agent-js">
+    Research Agent using the OpenAI Agents framework
+  </Card>
+  <Card title="MCP Client" icon="plug" href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/mcp-client-js">
+    Basic MCP client connecting to an E2B Sandbox
+  </Card>
+  <Card title="Custom MCP Server" icon="server" href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/mcp-custom-server-js">
+    Use custom MCP servers installed from GitHub
+  </Card>
+  <Card title="Custom Template" icon="box" href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/mcp-custom-template-js">
+    Create a custom E2B Sandbox with pre-installed MCP servers
   </Card>
 </CardGroup>
-
-


### PR DESCRIPTION
Approve/Merge once https://github.com/e2b-dev/e2b-cookbook/pull/71 is merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update MCP examples page to use e2b-cookbook links, add several new examples, and switch to a 3-column layout.
> 
> - **Docs**:
>   - **`docs/mcp/examples.mdx`**:
>     - Replace demo links with `e2b-cookbook` examples and expand list (Claude Code, Browserbase, Groq + Exa, Research Agent, MCP Client, Custom MCP Server, Custom Template).
>     - Change `CardGroup` layout from 2 to 3 columns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8e34abd5ea959f5b91e036c2f45e8f7632c4b4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->