### PR TITLE
Added note on migrate command (files rename)

### DIFF
--- a/docs/template/migration-v2.mdx
+++ b/docs/template/migration-v2.mdx
@@ -27,12 +27,12 @@ To migrate the existing template definition to the new format, follow these step
         Navigate to the folder of your existing template definition (where you have `e2b.toml` and `e2b.Dockerfile` files).
     </Step>
     <Step title="Run migration command">
+      <Note>
+        Your existing `e2b.toml` and `e2b.Dockerfile` files will be renamed to `e2b.toml.old` and `e2b.Dockerfile.old`, respectively, as they are no longer required.
+      </Note>
       ```bash
       e2b template migrate
       ```
-      <Note>
-        Your existing e2b.toml and e2b.Dockerfile will be renamed to e2b.toml.old and e2b.Dockerfile.old respectively as these are no longer required.
-      </Note>
     </Step>
     <Step title="Follow the prompts">
         Follow the prompts to complete the migration process.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a note to the migration guide that `e2b.toml` and `e2b.Dockerfile` are renamed to `.old` during `e2b template migrate`.
> 
> - **Docs**:
>   - Update `docs/template/migration-v2.mdx` to include a note that `e2b.toml` and `e2b.Dockerfile` are renamed to `e2b.toml.old` and `e2b.Dockerfile.old` when running `e2b template migrate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7d3eda685dde6196c63c01417f4316a8f30b607. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->