### PR TITLE
Added "The sandbox is running but port is not open" troubleshooting guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -187,7 +187,8 @@
               {
                 "group": "Templates",
                 "pages": [
-                  "docs/troubleshooting/templates/build-authentication-error"
+                  "docs/troubleshooting/templates/build-authentication-error",
+                  "docs/troubleshooting/templates/49999-port-not-open"
                 ]
               }
             ]

--- a/docs/troubleshooting/templates/49999-port-not-open.mdx
+++ b/docs/troubleshooting/templates/49999-port-not-open.mdx
@@ -1,0 +1,51 @@
+---
+title: "The sandbox is running but port is not open - 49999"
+sidebarTitle: The sandbox is running but port is not open - 49999
+---
+
+When trying to create a custom sandbox template, you might encounter the issue when trying to call `.runCode` / `.run_code` method using the E2B Code Interpreter SDK.
+
+The reason for this is that either the default start command is not specified on the template or that the base image is other than the Code Interpreter image thus the Code Interpreter inside the sandbox cannot be started.
+
+**Example error**
+
+```txt
+{"sandboxId":"ilmqag7sxz49zjc3gex7x","message":"The sandbox is running but port is not open","port":49999,"code":502}: This error is likely due to sandbox timeout. You can modify the sandbox timeout by passing 'timeout' when starting the sandbox or calling '.set_timeout' on the sandbox with the desired timeout.
+```
+
+## Solution
+
+### Current Build System (V2)
+
+With the current build system, you need to use the `code-interpreter` as a base template in your template definition.
+
+<Note>
+    The default start command for the `code-interpreter` template is `/root/.jupyter/start-up.sh`.
+</Note>
+
+<CodeGroup>
+```js JavaScript & TypeScript
+import { Template } from '@e2b/code-interpreter'
+
+const template = Template().fromTemplate("code-interpreter")
+```
+```python Python
+from e2b_code_interpreter import Template
+
+template = Template().from_template("code-interpreter")
+```
+</CodeGroup>
+
+### Legacy Build System
+
+If you are using the legacy build system, you need to use Code Interpreter image as a base image:
+
+```Dockerfile
+FROM e2bdev/code-interpreter:latest
+```
+
+And build the sandbox template with the start command:
+
+```sh
+e2b template build -c "/root/.jupyter/start-up.sh"
+```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new troubleshooting guide for "The sandbox is running but port is not open - 49999" and links it in docs navigation.
> 
> - **Docs**:
>   - **Troubleshooting > Templates**: New page `docs/troubleshooting/templates/49999-port-not-open.mdx` describing causes and solutions (V2 base template `code-interpreter`, legacy Docker base image and start command) with example error and code snippets.
> - **Navigation**:
>   - Update `docs.json` to include `docs/troubleshooting/templates/49999-port-not-open` under `Troubleshooting > Templates`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cd69bd23359f7c8866d3cccaed507b9622a6234. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->