### PR TITLE
fix: broken mcp links

### DIFF
--- a/docs/mcp.mdx
+++ b/docs/mcp.mdx
@@ -90,20 +90,19 @@ if __name__ == "__main__":
 ## Documentation
 
 <CardGroup cols={2}>
-  <Card title="Quickstart" icon="rocket" href="mcp/quickstart">
+  <Card title="Quickstart" icon="rocket" href="/docs/mcp/quickstart">
     Get started with MCP
   </Card>
-  <Card title="Available Servers" icon="server" href="mcp/available-servers">
+  <Card title="Available Servers" icon="server" href="/docs/mcp/available-servers">
     Browse 200+ pre-built MCP servers
   </Card>
-  <Card title="Custom Templates" icon="cube" href="mcp/custom-templates">
+  <Card title="Custom Templates" icon="cube" href="/docs/mcp/custom-templates">
     Prepull MCP servers for faster runtime
   </Card>
-  <Card title="Custom Servers" icon="github" href="mcp/custom-servers">
+  <Card title="Custom Servers" icon="github" href="/docs/mcp/custom-servers">
     Use custom MCP servers from GitHub
   </Card>
-  <Card title="Examples" icon="code" href="mcp/examples">
+  <Card title="Examples" icon="code" href="/docs/mcp/examples">
     See examples
   </Card>
 </CardGroup>
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fix MCP docs Card links to absolute `/docs/...` paths in `docs/mcp.mdx`.
> 
> - **Docs**:
>   - Update links in `docs/mcp.mdx` CardGroup to use absolute paths under `/docs/...` for:
>     - `Quickstart`, `Available Servers`, `Custom Templates`, `Custom Servers`, `Examples`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a9b65a8f3fc5fc99609745161b3079f4e953a9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->