### PR TITLE
fix: mcp custom template logger

### DIFF
--- a/docs/mcp/custom-templates.mdx
+++ b/docs/mcp/custom-templates.mdx
@@ -22,7 +22,7 @@ The server names (like `"browserbase"` and `"exa"`) correspond to the keys defin
 
 ```typescript JavaScript & TypeScript
 import "dotenv/config";
-import { Template } from "e2b";
+import { Template, defaultBuildLogger } from "e2b";
 
 export const template = Template()
   .fromTemplate("mcp-gateway")
@@ -32,13 +32,13 @@ await Template.build(template, {
   alias: "my-mcp-gateway",
   cpuCount: 8,
   memoryMB: 8192,
-  onBuildLogs: console.log,
+  onBuildLogs: defaultBuildLogger(),
 });
 ```
 
 ```python Python
 from dotenv import load_dotenv
-from e2b import Template
+from e2b import Template, default_build_logger
 
 load_dotenv()
 
@@ -53,6 +53,7 @@ Template.build(
     alias="my-mcp-gateway",
     cpu_count=8,
     memory_mb=8192,
+    on_build_logs=default_build_logger(),
 )
 ```
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates MCP custom template docs to use the default build logger in TypeScript and Python examples, plus a minor list formatting fix.
> 
> - **Docs (`docs/mcp/custom-templates.mdx`)**:
>   - **Code samples**:
>     - TypeScript: import `defaultBuildLogger` and pass `onBuildLogs: defaultBuildLogger()` (replacing `console.log`).
>     - Python: import `default_build_logger` and pass `on_build_logs=default_build_logger()`.
>   - **Formatting**: fix trailing list item for `Template Build` link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9fb169346ada8fd456f4eaa6a0b4938b3e7596a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->