### PR TITLE
Revise README for E2B Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,7 @@
-# Mintlify Starter Kit
+# E2B Docs
 
-Click on `Use this template` to copy the Mintlify starter kit. The starter kit contains examples including
+This is an official E2B documentation deployed at [e2b.dev/docs](https://e2b.dev/docs).
 
-- Guide pages
-- Navigation
-- Customizations
-- API Reference pages
-- Use of popular components
 
 ### Development
 
@@ -21,12 +16,3 @@ Run the following command at the root of your documentation (where mint.json is)
 ```
 mintlify dev
 ```
-
-### Publishing Changes
-
-Install our Github App to auto propagate changes from your repo to your deployment. Changes will be deployed to production automatically after pushing to the default branch. Find the link to install on your dashboard. 
-
-#### Troubleshooting
-
-- Mintlify dev isn't running - Run `mintlify install` it'll re-install dependencies.
-- Page loads as a 404 - Make sure you are running in a folder with `mint.json`


### PR DESCRIPTION
Updated documentation to reflect E2B branding and removed outdated sections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revamps README with E2B branding, adds docs link, and removes outdated starter kit/publishing/troubleshooting sections.
> 
> - **Docs**:
>   - **README** (`README.md`):
>     - Rename title to `E2B Docs` and add link to official docs.
>     - Remove starter kit details, publishing, and troubleshooting sections.
>     - Retain concise development instructions for running `mintlify dev`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e790c863a4887fe9cbe6b99404fc001391dfa08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->