### PR TITLE
bugfix - openai example updated to use execution.logs.stdout

### DIFF
--- a/docs/quickstart/connect-llms.mdx
+++ b/docs/quickstart/connect-llms.mdx
@@ -74,7 +74,7 @@ model = "gpt-4o"
 messages = [
     {
         "role":"system",
-        "content":"You are a helpful assistant that can execute python code in a Jupyter notebook. Only respond with the code to be executed and nothing else; strip backticks in code blocks and don't begin with python. Always use code for calculations rather than assume the answer and always print the output of code rather than displaying it."
+        "content":"You are a helpful assistant that can execute python code in a Jupyter notebook. When running code, only respond with the code to be executed and nothing else; strip backticks in code blocks and don't begin with python. Always use code for calculations rather than assume the answer and always print the output of code rather than displaying it."
     },
     {
         "role": "user",


### PR DESCRIPTION
Updates the openai onboarding example to use `execution.logs.stdout` rather than `execution.text`.

Previously it was using execution.text which doesn't exist on the Execution. The Execution can have a `Response` and `Logs` consisting of `stdout`, `stderr` which are anything that were printed. Since the other examples use the logs just going with this.

In order to guarantee the output has a `stdout` also changed the system prompt to include that the AI should always use a function to calculate results as well as print the output. If it just displays the output
```
word = 'strawberry'
count_r = word.count('r')
count_r
```
That'll end up in the `Response` and that'll need to be handled differently which seems outside the scope of this onboarding but maybe that should be handled.

This change more reliably gets us
```
word = 'strawberry'
count_r = word.count('r')
print(count_r)
```

This'll need to be handled for the other models as well possibly but haven't tested those yet.