### PR TITLE
Update code interpreter alias in troubleshooting

### DIFF
--- a/docs/troubleshooting/templates/49999-port-not-open.mdx
+++ b/docs/troubleshooting/templates/49999-port-not-open.mdx
@@ -27,12 +27,12 @@ With the current build system, you need to use the `code-interpreter` as a base 
 ```js JavaScript & TypeScript
 import { Template } from '@e2b/code-interpreter'
 
-const template = Template().fromTemplate("code-interpreter")
+const template = Template().fromTemplate("code-interpreter-v1")
 ```
 ```python Python
 from e2b_code_interpreter import Template
 
-template = Template().from_template("code-interpreter")
+template = Template().from_template("code-interpreter-v1")
 ```
 </CodeGroup>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update troubleshooting docs to use `code-interpreter-v1` as the base template in SDK examples.
> 
> - **Docs**:
>   - Update `docs/troubleshooting/templates/49999-port-not-open.mdx`:
>     - Switch SDK examples to `code-interpreter-v1` in `Template().fromTemplate` (JS/TS) and `Template().from_template` (Python).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b8d5916db6ba98cdf514c0eee856126871fb00b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->