### PR TITLE
Add a link to billing for purchasing add-on

### DIFF
--- a/docs/sandbox/rate-limits.mdx
+++ b/docs/sandbox/rate-limits.mdx
@@ -16,45 +16,45 @@ This page describes API and sandbox rate limits of the E2B platform.
 
 Here's a limits breakdown table based on the plan:
 
-<table style={{ display: 'inline-table', margin: '0 auto', border: '2px solid #FFB766', borderCollapse: 'collapse' }}>
+<table style={{ display: 'inline-table', margin: '0 auto', borderCollapse: 'collapse' }}>
   <thead>
     <tr style={{ background: '#000', color: 'white' }}>
-      <th style={{ textAlign: 'left', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766', color: 'white' }}>Plan</th>
-      <th style={{ textAlign: 'center', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766', color: 'white' }}>Hobby</th>
-      <th style={{ textAlign: 'center', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766', color: 'white' }}>Pro</th>
-      <th style={{ textAlign: 'center', padding: '8px', border: '2px solid #FFB766', color: 'white' }}>Enterprise</th>
+      <th style={{ textAlign: 'left', padding: '8px', color: 'white' }}>Plan</th>
+      <th style={{ textAlign: 'center', padding: '8px', color: 'white' }}>Hobby</th>
+      <th style={{ textAlign: 'center', padding: '8px', color: 'white' }}>Pro</th>
+      <th style={{ textAlign: 'center', padding: '8px', color: 'white' }}>Enterprise</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td style={{ fontWeight: 'bold', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766' }}>Sandbox lifecycle &amp; management API</td>
-      <td style={{ textAlign: 'center', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766' }}>20,000 / 30s</td>
-      <td style={{ textAlign: 'center', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766' }}>20,000 / 30s</td>
-      <td style={{ textAlign: 'center', padding: '8px', border: '2px solid #FFB766' }}>Custom</td>
+      <td style={{ fontWeight: 'bold', padding: '8px' }}>Sandbox lifecycle &amp; management API</td>
+      <td style={{ textAlign: 'center', padding: '8px' }}>20,000 / 30s</td>
+      <td style={{ textAlign: 'center', padding: '8px' }}>20,000 / 30s</td>
+      <td style={{ textAlign: 'center', padding: '8px' }}>Custom</td>
     </tr>
     <tr>
-      <td style={{ fontWeight: 'bold', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766' }}>Sandbox operations</td>
-      <td style={{ textAlign: 'center', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766' }}>40,000 / 60s per IP</td>
-      <td style={{ textAlign: 'center', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766' }}>40,000 / 60s per IP</td>
-      <td style={{ textAlign: 'center', padding: '8px', border: '2px solid #FFB766' }}>Custom</td>
+      <td style={{ fontWeight: 'bold', padding: '8px' }}>Sandbox operations</td>
+      <td style={{ textAlign: 'center', padding: '8px' }}>40,000 / 60s per IP</td>
+      <td style={{ textAlign: 'center', padding: '8px' }}>40,000 / 60s per IP</td>
+      <td style={{ textAlign: 'center', padding: '8px' }}>Custom</td>
     </tr>
     <tr>
-      <td style={{ fontWeight: 'bold', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766' }}>Concurrent sandboxes</td>
-      <td style={{ textAlign: 'center', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766' }}>20</td>
-      <td style={{ textAlign: 'center', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766' }}>100 - 1,100<b><sup>*</sup></b></td>
-      <td style={{ textAlign: 'center', padding: '8px', border: '2px solid #FFB766' }}>Custom</td>
+      <td style={{ fontWeight: 'bold', padding: '8px' }}>Concurrent sandboxes</td>
+      <td style={{ textAlign: 'center', padding: '8px' }}>20</td>
+      <td style={{ textAlign: 'center', padding: '8px' }}>100 - 1,100<b><sup>*</sup></b></td>
+      <td style={{ textAlign: 'center', padding: '8px' }}>Custom</td>
     </tr>
     <tr>
-      <td style={{ fontWeight: 'bold', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766' }}>Sandbox creation rate</td>
-      <td style={{ textAlign: 'center', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766' }}>1 / sec</td>
-      <td style={{ textAlign: 'center', padding: '8px', borderRight: '2px solid #FFB766', border: '2px solid #FFB766' }}>5 / sec</td>
-      <td style={{ textAlign: 'center', padding: '8px', border: '2px solid #FFB766' }}>Custom</td>
+      <td style={{ fontWeight: 'bold', padding: '8px' }}>Sandbox creation rate</td>
+      <td style={{ textAlign: 'center', padding: '8px' }}>1 / sec</td>
+      <td style={{ textAlign: 'center', padding: '8px' }}>5 / sec</td>
+      <td style={{ textAlign: 'center', padding: '8px' }}>Custom</td>
     </tr>
   </tbody>
 </table>
 
 <Note>
-  <b><sup>*</sup></b> Pro plan default is 100 concurrent sandboxes. Higher concurrency of up to 1,100 is available as a separate purchasable add-on.
+  <b><sup>*</sup></b>Pro plan default is 100 concurrent sandboxes. Higher concurrency of up to 1,100 is available as a separate purchasable add-on.
 </Note>
 
 ---


### PR DESCRIPTION
Now
<img width="741" height="370" alt="image" src="https://github.com/user-attachments/assets/27ebe268-85f9-4349-85fc-e6dc2829e253" />
Before
<img width="784" height="409" alt="image" src="https://github.com/user-attachments/assets/81c3cd5c-670e-453a-8321-b3c174c6ab86" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the rate limits page table styling and copy, adding a billing link for purchasing concurrency add-ons.
> 
> - **Docs** (`docs/sandbox/rate-limits.mdx`):
>   - **Table styling**: Centered `inline-table`, removed per-cell borders and right borders for cleaner layout.
>   - **Copy updates**:
>     - Clarified Pro plan concurrency note and hyphenation of “add-on(s)”.
>     - Added billing link for purchasing concurrency add-ons.
>     - Minor grammar/punctuation fixes in examples and notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d3def5db52df56a1141f54a3e9bd061cd79357c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->