### PR TITLE
fix: update install custom packages tutorial to use the v2 build system

### DIFF
--- a/docs/quickstart/install-custom-packages.mdx
+++ b/docs/quickstart/install-custom-packages.mdx
@@ -13,96 +13,128 @@ There are two ways to install custom packages in the E2B Sandbox.
 
 Use this option if you know beforehand what packages you need in the sandbox.
 
-Prerequisites:
-- E2B CLI
-- Docker running
-
 <Note>
-Custom sandbox template is a Docker image that we automatically convert to a sandbox that you can then start with our SDK.
+Sandbox templates allow you to define custom sandboxes with preinstalled packages and configurations.
 </Note>
 
-
-### 1. Install E2B CLI
-
-**Using Homebrew (on macOS)**
+### 1. Install the E2B SDK
 
 <CodeGroup>
-```bash Terminal
-brew install e2b
+```bash JavaScript & TypeScript
+npm install e2b dotenv
+```
+```bash Python
+pip install e2b python-dotenv
 ```
 </CodeGroup>
 
-**Using NPM**
+Create a `.env` file with your API key:
+```bash
+E2B_API_KEY=e2b_***
+```
+
+### 2. Create a template file
+
+Define your custom template with the packages you need.
 
 <CodeGroup>
-```bash Terminal
-npm i -g @e2b/cli
+```typescript JavaScript & TypeScript
+// template.ts
+import { Template } from "e2b";
+
+export const template = Template()
+  .fromTemplate("code-interpreter-v1")
+  .pipInstall(['cowsay'])  // Install Python packages
+  .npmInstall(['cowsay']);  // Install Node.js packages
+```
+
+```python Python
+# template.py
+from e2b import Template
+
+template = (
+    Template()
+    .from_template("code-interpreter-v1")
+    .pip_install(['cowsay'])  # Install Python packages
+    .npm_install(['cowsay'])  # Install Node.js packages
+)
 ```
 </CodeGroup>
 
-### 2. Login to E2B CLI
-Before you can create a custom sandbox, you need to login to E2B CLI.
+### 3. Create a build script
+
 <CodeGroup>
-```bash Terminal
-e2b auth login
+```typescript JavaScript & TypeScript
+// build.prod.ts
+import "dotenv/config";
+import { Template, defaultBuildLogger } from "e2b";
+import { template } from "./template";
+
+async function main() {
+  await Template.build(template, {
+    alias: "custom-packages",
+    cpuCount: 2,
+    memoryMB: 2048,
+    onBuildLogs: defaultBuildLogger(),
+  });
+}
+
+main().catch(console.error);
+```
+
+```python Python
+# build.prod.py
+from dotenv import load_dotenv
+from e2b import Template, default_build_logger
+from template import template
+
+load_dotenv()
+
+if __name__ == '__main__':
+    Template.build(
+        template,
+        alias="custom-packages",
+        cpu_count=2,
+        memory_mb=2048,
+        on_build_logs=default_build_logger(),
+    )
 ```
 </CodeGroup>
 
-### 2. Initialize a sandbox template
+### 4. Build the template
+
+Run the build script to create your custom template:
+
 <CodeGroup>
-```bash Terminal
-e2b template init
+```bash JavaScript & TypeScript
+npx tsx build.prod.ts
+```
+
+```bash Python
+python build.prod.py
 ```
 </CodeGroup>
 
-### 3. Specify the packages you need in `e2b.Dockerfile`
-Edit the E2B Dockerfile to install the packages you need.
+This will build your template and you'll see build logs in the console.
 
-<Note>
-You need to use the `e2bdev/code-interpreter:latest` base image.
-</Note>
+### 5. Use your custom sandbox
 
-<CodeGroup>
-```bash e2b.Dockerfile
-FROM e2bdev/code-interpreter:latest
+Now you can create sandboxes from your custom template:
 
-RUN pip install cowsay
-RUN npm install cowsay
-```
-</CodeGroup>
-
-### 4. Build the sandbox template
-Run the following command to build the sandbox template.
-<CodeGroup>
-```bash Terminal
-e2b template build -c "/root/.jupyter/start-up.sh"
-```
-</CodeGroup>
-
-This will take a while, as it convert the Docker image to a sandbox which is a small VM.
-At the end of the process you will see the sandbox ID like this:
-```
-Running postprocessing. It can take up to few minutes.
-
-Postprocessing finished.
-
-✅ Building sandbox template YOUR_TEMPLATE_ID finished.
-```
-
-### 5. Start your custom sandbox
-Now you can pass the template ID to the SDK to start your custom sandbox.
 <CodeGroup>
 ```js JavaScript & TypeScript
-import { Sandbox } from '@e2b/code-interpreter'
+import { Sandbox } from 'e2b'
 
-const sbx = Sandbox.create({
-  template: 'YOUR_TEMPLATE_ID',
-})
+const sbx = await Sandbox.create("custom-packages")
+
+// Your packages are already installed and ready to use
 ```
 ```python Python
-from e2b_code_interpreter import Sandbox
+from e2b import Sandbox
 
-sbx = Sandbox.create(template='YOUR_TEMPLATE_ID')
+sbx = Sandbox.create("custom-packages")
+
+# Your packages are already installed and ready to use
 ```
 </CodeGroup>
 
@@ -122,7 +154,7 @@ When you start a new sandbox instance, the packages are not be available.
 ```js JavaScript & TypeScript
 import { Sandbox } from '@e2b/code-interpreter'
 
-const sbx = Sandbox.create()
+const sbx = await Sandbox.create()
 sbx.commands.run('pip install cowsay') // This will install the cowsay package
 sbx.runCode(`
   import cowsay
@@ -147,7 +179,7 @@ sbx.run_code("""
 ```js JavaScript & TypeScript
 import { Sandbox } from '@e2b/code-interpreter'
 
-const sbx = Sandbox.create()
+const sbx = await Sandbox.create()
 sbx.commands.run('npm install cowsay') // This will install the cowsay package
 sbx.runCode(`
   const cowsay = require('cowsay')
@@ -177,7 +209,7 @@ For example, to install `curl` and `git`, you can use the following commands:
 ```js JavaScript & TypeScript
 import { Sandbox } from '@e2b/code-interpreter'
 
-const sbx = Sandbox.create()
+const sbx = await Sandbox.create()
 await sbx.commands.run('apt-get update && apt-get install -y curl git')
 ```
 ```python Python


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Rewrites the custom packages guide to use the v2 SDK-based template build and updates runtime install examples and Sandbox usage.
> 
> - **Docs — Quickstart (`docs/quickstart/install-custom-packages.mdx`)**:
>   - **Switch to v2 SDK template flow**:
>     - Replace CLI/Dockerfile-based steps with SDK-driven templates (`Template().fromTemplate(...)`) in TS/Python.
>     - Add build scripts (`build.prod.ts`/`build.prod.py`) using `Template.build` with alias/resources and build logs.
>     - Show building via `npx tsx build.prod.ts` or `python build.prod.py`.
>   - **Usage updates**:
>     - Start sandboxes by alias (e.g., `Sandbox.create("custom-packages")`).
>     - Update examples to `await Sandbox.create()` where needed and modernize code snippets.
>   - **Cleanup/Removals**:
>     - Remove E2B CLI login/init steps and Dockerfile-based package installation instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b4b6b4d2c83afb969b01ec09b60c57e4141853d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->